### PR TITLE
feat: throw error if provided identifier is undefined

### DIFF
--- a/contracts/identifier.go
+++ b/contracts/identifier.go
@@ -17,6 +17,10 @@ func NewIdentifier(id any) Identifier {
 	var kind IdKind
 	var length int
 
+	if id == "" {
+		panic("Id must be defined")
+	}
+
 	switch v := id.(type) {
 	case int:
 		kind = NumericId


### PR DESCRIPTION
Hello,

While I was using this SDK, I met error due a missing variable and I spent lot of time to understand the issue. I would like to warn directly the user that a required property is missing in this case.

Honestly I do not know well how to handle it. Panic is not wanted but returning an error would also break the contract. Is logging an error enough?

Happy to hear your feedback!